### PR TITLE
ci: ensure shellcheck finds root dotfiles

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # --- Config shortcuts ---
 alias zshconfig="vi ~/.zshrc"
 alias aliasconfig="vi ~/.bash_aliases"

--- a/.bashrc
+++ b/.bashrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Minimal Fedora-focused Bash config
 
 # Source global definitions (present on Fedora)

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -27,14 +27,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t files < <(git ls-files \
-            '**/*.sh' \
-            '**/*.bash' \
-            '**/*.zsh' \
-            '**/.bashrc' \
-            '**/.bash_aliases' \
-            '**/.zshrc' \
-            '**/.profile')
+          mapfile -t files < <(git ls-files -- \
+            ':(glob)**/*.sh' \
+            ':(glob)**/*.bash' \
+            ':(glob)**/*.zsh' \
+            ':(glob)**/.bashrc' \
+            ':(glob)**/.bash_aliases' \
+            ':(glob)**/.zshrc' \
+            ':(glob)**/.profile')
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No shell files to check."
             exit 0

--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # --- Oh My Zsh ---
 export ZSH="$HOME/.oh-my-zsh"
 export EDITOR="vim"


### PR DESCRIPTION
## Summary
- use glob pathspecs so git ls-files returns dotfiles at repo root
- keep shellcheck running even when only dotfiles change

## Testing
- relying on GitHub Actions