### PR TITLE
chore(shell): drop oh my zsh; split .zshenv; add history hygiene

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -1,0 +1,26 @@
+# shellcheck shell=bash
+# ~/.zshenv — sourced for every shell (interactive, scripts, AI agent subshells).
+# PATH and env vars belong here so non-interactive callers see them.
+
+export EDITOR="vim"
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
+# Dotfiles root (portable default)
+export DOTFILES_DIR="${DOTFILES_DIR:-$HOME/Dev/dotfiles}"
+
+# --- Homebrew (macOS) ---
+if [[ "$OSTYPE" == darwin* ]] && [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+# --- User local bins ---
+[ -d "$HOME/.local/bin" ] && export PATH="$HOME/.local/bin:$PATH"
+
+# --- nvm (path only; nvm.sh is sourced in .zshrc to keep script-launch cheap) ---
+export NVM_DIR="$HOME/.nvm"
+
+# --- pyenv (shims on PATH so non-interactive `python` resolves correctly) ---
+export PYENV_ROOT="$HOME/.pyenv"
+[ -d "$PYENV_ROOT/bin" ] && export PATH="$PYENV_ROOT/bin:$PATH"
+[ -d "$PYENV_ROOT/shims" ] && export PATH="$PYENV_ROOT/shims:$PATH"

--- a/.zshrc
+++ b/.zshrc
@@ -1,29 +1,23 @@
 # shellcheck shell=bash
-# --- Oh My Zsh ---
-export ZSH="$HOME/.oh-my-zsh"
-export EDITOR="vim"
-export LANG=en_US.UTF-8
-export LC_ALL=en_US.UTF-8
-ZSH_THEME="robbyrussell"
+# ~/.zshrc — interactive zsh config. Env/PATH lives in ~/.zshenv.
 
-# --- Dotfiles root (portable default) ---
-# macOS default was hardcoded; now it falls back to ~/Dev/dotfiles on Linux
-export DOTFILES_DIR="${DOTFILES_DIR:-$HOME/Dev/dotfiles}"
+# --- Prompt ---
+# Starship if installed; otherwise leave the default prompt.
+command -v starship >/dev/null && eval "$(starship init zsh)"
 
-# --- Plugins ---
-plugins=(git zsh-autosuggestions fast-syntax-highlighting zsh-autocomplete)
-[ -s "$ZSH/oh-my-zsh.sh" ] && source "$ZSH/oh-my-zsh.sh"
+# --- Plugins (no framework; clone directly into ~/.zsh/plugins) ---
+for p in zsh-autosuggestions fast-syntax-highlighting; do
+  src="$HOME/.zsh/plugins/$p/$p.zsh"
+  [ -f "$src" ] && source "$src"
+done
 
-# --- PATH ---
-export PATH="$HOME/.local/bin:$PATH"
+# --- History ---
+HISTFILE="$HOME/.zsh_history"
+HISTSIZE=100000
+SAVEHIST=100000
+setopt SHARE_HISTORY HIST_IGNORE_DUPS HIST_IGNORE_SPACE INC_APPEND_HISTORY
 
-# --- FZF (optional) ---
-[ -f "$HOME/.fzf.zsh" ] && source "$HOME/.fzf.zsh"
-
-# --- Completion (single init) ---
-zstyle ':completion:*' rehash true
-
-# --- Homebrew zsh completions (macOS only) ---
+# --- Homebrew zsh completions (macOS) ---
 if [[ "$OSTYPE" == darwin* ]]; then
   if [ -d /opt/homebrew/share/zsh/site-functions ]; then
     fpath=(/opt/homebrew/share/zsh/site-functions $fpath)
@@ -32,18 +26,26 @@ if [[ "$OSTYPE" == darwin* ]]; then
   fi
 fi
 
+# --- Completion ---
+# -C skips the insecure-dir check; brew/pyenv dirs are 755 by design.
 autoload -Uz compinit && compinit -C
+zstyle ':completion:*' rehash true
 
 # --- Aliases ---
 [ -f "$HOME/.bash_aliases" ] && source "$HOME/.bash_aliases"
 
-# --- NVM (optional) ---
-# export NVM_DIR="$HOME/.nvm"
-# [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-# [ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"
+# --- nvm (sourced here, not in .zshenv, to keep non-interactive shell startup cheap) ---
+[ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"
+[ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
 
-# --- Pyenv (optional) ---
-# export PYENV_ROOT="$HOME/.pyenv"
-# command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
-# eval "$(pyenv init --path)"
-# eval "$(pyenv init -)"
+# --- pyenv (interactive completion + rehash hooks; shims are on PATH via .zshenv) ---
+command -v pyenv >/dev/null && eval "$(pyenv init - zsh)"
+
+# --- FZF integration ---
+if command -v fzf >/dev/null; then
+  if [[ -d /opt/homebrew/opt/fzf ]]; then
+    source /opt/homebrew/opt/fzf/shell/key-bindings.zsh
+    source /opt/homebrew/opt/fzf/shell/completion.zsh
+  fi
+  [ -f "$HOME/.fzf.zsh" ] && source "$HOME/.fzf.zsh"
+fi

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Provides a simple, repeatable setup for shell, Git, Vim, and VS Code.
 ## Features
 
 - **Shell Configuration**
-  - `.zshrc` with [Oh My Zsh](https://ohmyz.sh/), plugins, and environment variables
+  - `.zshenv` for PATH/env — loaded by every shell, including non-interactive subshells (AI agents, scripts)
+  - `.zshrc` for interactive setup — framework-free; plugins cloned directly into `~/.zsh/plugins`
+  - Optional [Starship](https://starship.rs) prompt (auto-detected)
   - `.bash_aliases` with handy shortcuts (portable across macOS/Linux)
   - Portable `open` alias → `open .` on macOS, `xdg-open .` on Linux
 
@@ -45,9 +47,9 @@ Provides a simple, repeatable setup for shell, Git, Vim, and VS Code.
 - **macOS** or **Fedora/Linux**
 - Git
 - Vim
-- [Oh My Zsh](https://ohmyz.sh/)
 - [VS Code](https://code.visualstudio.com/) (with CLI `code` available in `$PATH`)
 - Optional tools:
+  - [Starship](https://starship.rs) prompt — `brew install starship` (macOS) or `cargo install starship` / package manager (Linux)
   - shfmt (shell formatter) for on-save formatting in VS Code — install via `brew install shfmt` (macOS) or `sudo dnf install shfmt` (Fedora)
   - [fzf](https://github.com/junegunn/fzf) for `vf`/`cf` aliases
   - Yarn if you use the Node.js aliases
@@ -70,7 +72,7 @@ Provides a simple, repeatable setup for shell, Git, Vim, and VS Code.
    ./install.sh
    ```
 
-   This links your dotfiles, sets up VS Code user settings, and installs/updates core Zsh plugins (if Oh My Zsh is present).
+   This links your dotfiles, sets up VS Code user settings, and clones the Zsh plugins into `~/.zsh/plugins`.
 
 3. **Git setup:** Already run by `./install.sh` when `git-config-setup.sh` is present.
 

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,7 @@ esac
 # --------- Dotfiles ---------
 info "Symlinking dotfiles to home directory..."
 link "$DOTFILES_DIR/.zshrc" "$HOME/.zshrc"
+link "$DOTFILES_DIR/.zshenv" "$HOME/.zshenv"
 link "$DOTFILES_DIR/.bash_aliases" "$HOME/.bash_aliases"
 link "$DOTFILES_DIR/.vimrc" "$HOME/.vimrc"
 ok "Dotfiles symlinked."
@@ -101,43 +102,26 @@ else
   info "git-config-setup.sh not found; skipping."
 fi
 
-# --------- Zsh Plugins (Oh My Zsh essentials) ---------
+# --------- Zsh Plugins (framework-free; cloned into ~/.zsh/plugins) ---------
 info "Ensuring Zsh plugins are installed..."
-ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
-if [[ ! -d "${ZSH_CUSTOM%/}/.." ]]; then
-  info "Oh My Zsh not found. Install: https://ohmyz.sh"
-else
-  need git
-  plugins=(
-    "zsh-autosuggestions|https://github.com/zsh-users/zsh-autosuggestions.git"
-    "fast-syntax-highlighting|https://github.com/zdharma-continuum/fast-syntax-highlighting.git"
-    "zsh-autocomplete|https://github.com/marlonrichert/zsh-autocomplete.git"
-  )
-  for entry in "${plugins[@]}"; do
-    name="${entry%%|*}"; url="${entry#*|}"
-    dest="$ZSH_CUSTOM/plugins/$name"
-    if [[ -d "$dest/.git" ]]; then
-      # Determine remote default branch (avoid noisy failures on repos using master)
-      default_branch="$(git -C "$dest" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | awk -F/ '{print $2}')"
-      if [[ -z "$default_branch" ]]; then
-        default_branch="$(git -C "$dest" remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')"
-      fi
-      [[ -z "$default_branch" ]] && default_branch=main
-      git -C "$dest" fetch --prune --depth=1 origin "$default_branch" || git -C "$dest" fetch --prune --depth=1 origin
-      git -C "$dest" reset --hard FETCH_HEAD || true
-    else
-      mkdir -p -- "$(dirname "$dest")"
-      # Clone the remote's default branch if detectable; fall back to default
-      db="$(git ls-remote --symref "$url" HEAD 2>/dev/null | awk '/^ref:/ {print $3}' | sed 's!.*/!!')"
-      if [[ -n "$db" ]]; then
-        git clone --depth=1 --branch "$db" "$url" "$dest" || git clone --depth=1 "$url" "$dest" || echo "Clone failed: $name"
-      else
-        git clone --depth=1 "$url" "$dest" || echo "Clone failed: $name"
-      fi
-    fi
-    ok "$name ready"
-  done
-fi
+need git
+PLUGIN_DIR="$HOME/.zsh/plugins"
+mkdir -p -- "$PLUGIN_DIR"
+plugins=(
+  "zsh-autosuggestions|https://github.com/zsh-users/zsh-autosuggestions.git"
+  "fast-syntax-highlighting|https://github.com/zdharma-continuum/fast-syntax-highlighting.git"
+)
+for entry in "${plugins[@]}"; do
+  name="${entry%%|*}"; url="${entry#*|}"
+  dest="$PLUGIN_DIR/$name"
+  if [[ -d "$dest/.git" ]]; then
+    git -C "$dest" fetch --prune --depth=1 origin || true
+    git -C "$dest" reset --hard FETCH_HEAD || true
+  else
+    git clone --depth=1 "$url" "$dest" || echo "Clone failed: $name"
+  fi
+  ok "$name ready"
+done
 
 ok "🎉 Setup complete."
 


### PR DESCRIPTION
## Summary

Trim shell config to post-AI essentials. Less framework, more reach into non-interactive shells (so AI agent subshells see the same PATH/env you do).

## Changes

- **`.zshrc`** rewritten without Oh My Zsh.
  - Plugins (`zsh-autosuggestions`, `fast-syntax-highlighting`) sourced directly from `~/.zsh/plugins`.
  - `zsh-autocomplete` dropped — noisy and largely redundant with AI-era workflows.
  - Optional [Starship](https://starship.rs) prompt auto-detected.
- **`.zshenv`** (new) carries `PATH`, `EDITOR`, `LANG`, `brew shellenv`, `pyenv` shims. Loaded by every shell, including non-interactive subshells (scripts, cron, AI agents). `nvm.sh` stays in `.zshrc` to keep script-launch cheap.
- **History config**: `HISTSIZE`/`SAVEHIST`/`SHARE_HISTORY`/`HIST_IGNORE_DUPS` — your shell history is now the audit trail of what you actually did vs. what the agent did.
- **`install.sh`**: symlinks `.zshenv` alongside `.zshrc`; plugin block clones into `~/.zsh/plugins` instead of the OMZ custom dir (which was conditional on OMZ being installed).
- **`README.md`** updated: OMZ no longer in Requirements; mentions optional Starship.

## Test plan

- [ ] Fresh terminal: `zsh` opens without errors; `echo $PATH` includes `/opt/homebrew/bin` and `~/.pyenv/shims`
- [ ] `which node` and `which python` resolve via nvm / pyenv shims
- [ ] Non-interactive: `zsh -c 'echo $PATH'` shows the same PATH (proves `.zshenv` is doing its job)
- [ ] `history` writes are shared across tabs
- [ ] `./install.sh` on a fresh box symlinks both `.zshrc` and `.zshenv`, clones the two plugins into `~/.zsh/plugins`
- [ ] ShellCheck / Yamllint / Actionlint CI all pass

## Follow-ups (not in this PR)

- `git-config-setup.sh` hard-codes a stale email (`benrozsame@gmail.com`) — actual commits use `robence@gmail.com`. Worth a small follow-up.
- `install.sh` references `vscode-extensions.txt` which doesn't exist in the repo — could read from `.vscode/extensions.json` instead.
- `.bashrc` hard-codes `/home/brozsa/.local/share/fnm`; should use `$HOME`.
- Consider migrating nvm → fnm (single binary, ~40× faster startup, works without sourcing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)